### PR TITLE
Add forgotten extension trait to widget prelude.

### DIFF
--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -49,6 +49,7 @@ pub mod prelude {
         docking_zone::UiDockingZoneExt,
         dropdown::UiDropdownExt,
         floating_panel::{FloatingPanelConfig, FloatingPanelLayout, UiFloatingPanelExt},
+        foldable::UiFoldableExt,
         icon::UiIconExt,
         label::{LabelConfig, SetLabelTextExt, UiLabelExt},
         menu::{


### PR DESCRIPTION
The `UiFoldableExt` was not included in the widget prelude module.