### PR TITLE
Reexport internal math crate.

### DIFF
--- a/src/animated_interaction.rs
+++ b/src/animated_interaction.rs
@@ -1,9 +1,8 @@
 use std::marker::PhantomData;
 
 use bevy::prelude::*;
-use sickle_math::ease::{Ease, ValueEasing};
 
-use crate::{FluxInteraction, FluxInteractionStopwatch, FluxInteractionUpdate};
+use crate::{FluxInteraction, FluxInteractionStopwatch, FluxInteractionUpdate, math::{Ease, ValueEasing}};
 
 pub struct AnimatedInteractionPlugin;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ pub mod ui_builder;
 pub mod ui_commands;
 pub mod ui_style;
 pub mod widgets;
+pub mod math {
+    pub use sickle_math::*;
+}
 
 use assets::BuiltInAssetsPlugin;
 use drag_interaction::DragInteractionPlugin;

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -49,6 +49,7 @@ pub mod prelude {
         docking_zone::UiDockingZoneExt,
         dropdown::UiDropdownExt,
         floating_panel::{FloatingPanelConfig, FloatingPanelLayout, UiFloatingPanelExt},
+        foldable::UiFoldableExt,
         icon::UiIconExt,
         label::{LabelConfig, SetLabelTextExt, UiLabelExt},
         menu::{


### PR DESCRIPTION
Reexport internal math crate to get access to `Ease` needed to construct custom widgets with the `AnimatedInteraction` bundle.