### PR TITLE
Fixes

### DIFF
--- a/crates/sickle_ui_scaffold/src/theme/pseudo_state.rs
+++ b/crates/sickle_ui_scaffold/src/theme/pseudo_state.rs
@@ -37,7 +37,7 @@ fn track_node_visibility(
 }
 
 #[derive(
-    Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Reflect, Serialize, Deserialize,
+    Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Reflect, Serialize, Deserialize,
 )]
 pub enum PseudoState {
     #[default]
@@ -61,7 +61,7 @@ pub enum PseudoState {
     Closed,
     Error,
     Resizable(CardinalDirection),
-    Custom(&'static str),
+    Custom(String),
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
@@ -85,8 +85,8 @@ impl PseudoStates {
         Self(Vec::new())
     }
 
-    pub fn has(&self, state: PseudoState) -> bool {
-        self.0.contains(&state)
+    pub fn has(&self, state: &PseudoState) -> bool {
+        self.0.contains(state)
     }
 
     pub fn add(&mut self, state: PseudoState) {

--- a/crates/sickle_ui_scaffold/src/theme/style_animation.rs
+++ b/crates/sickle_ui_scaffold/src/theme/style_animation.rs
@@ -238,6 +238,7 @@ pub struct AnimationSettings {
     pub hover: Option<LoopedAnimationConfig>,
     #[reflect(default)]
     pub pressed: Option<LoopedAnimationConfig>,
+    #[reflect(default)]
     pub delete_on_entered: bool,
 }
 

--- a/crates/sickle_ui_scaffold/src/ui_commands.rs
+++ b/crates/sickle_ui_scaffold/src/ui_commands.rs
@@ -546,7 +546,7 @@ impl<'a> ManagePseudoStateExt<'a> for EntityCommands<'a> {
             let pseudo_states = world.get_mut::<PseudoStates>(entity);
 
             if let Some(mut pseudo_states) = pseudo_states {
-                if !pseudo_states.has(state) {
+                if !pseudo_states.has(&state) {
                     pseudo_states.add(state);
                 }
             } else {

--- a/crates/sickle_ui_scaffold/src/ui_style.rs
+++ b/crates/sickle_ui_scaffold/src/ui_style.rs
@@ -20,7 +20,7 @@ use crate::theme::{
     icons::IconData,
     style_animation::{AnimationSettings, AnimationState, InteractionStyle},
     typography::SizedFont,
-    UiContext, 
+    UiContext,
 };
 
 pub use crate::FluxInteraction;

--- a/examples/docking_zone_splits.rs
+++ b/examples/docking_zone_splits.rs
@@ -220,7 +220,7 @@ fn update_test_pseudo_state_on_press(
                 match pseudo_states.get().len() {
                     0 => pseudo_states.add(PseudoState::Checked),
                     1 => pseudo_states.add(PseudoState::Empty),
-                    2 => match pseudo_states.has(PseudoState::Empty) {
+                    2 => match pseudo_states.has(&PseudoState::Empty) {
                         true => {
                             pseudo_states.add(PseudoState::Selected);
                         }

--- a/src/widgets/dropdown.rs
+++ b/src/widgets/dropdown.rs
@@ -134,7 +134,7 @@ fn update_drowdown_pseudo_state(
     mut commands: Commands,
 ) {
     for (panel, states) in &q_panels {
-        if states.has(PseudoState::Visible) {
+        if states.has(&PseudoState::Visible) {
             commands
                 .entity(panel.dropdown)
                 .add_pseudo_state(PseudoState::Open);


### PR DESCRIPTION
- `PseudoState` can't implement `Deserialize` properly unless it contains a `String`. I don't like it either...
- Add `#[reflect(default)]` to the `delete_on_entered` field. This field could use some documentation, it's pretty unclear what it does exactly.