### PR TITLE
Add default implementation for UiContext

### DIFF
--- a/crates/sickle_macros/src/ui_context.rs
+++ b/crates/sickle_macros/src/ui_context.rs
@@ -5,16 +5,7 @@ pub(crate) fn derive_ui_context_macro(ast: &syn::DeriveInput) -> TokenStream {
     let name_ident = &ast.ident;
     let ident_name = name_ident.to_string();
     quote! {
-        impl UiContext for #name_ident {
-            fn get(&self, context: &str) -> Result<Entity, String> {
-                Err(format!("{} has no UI contexts", #ident_name))
-            }
-
-            fn contexts(&self) -> Vec<&'static str> {
-                vec![]
-            }
-        }
-
+        impl UiContext for #name_ident { }
     }
     .into()
 }

--- a/crates/sickle_ui_scaffold/src/theme.rs
+++ b/crates/sickle_ui_scaffold/src/theme.rs
@@ -134,8 +134,15 @@ impl PseudoTheme {
 }
 
 pub trait UiContext {
-    fn get(&self, target: &str) -> Result<Entity, String>;
-    fn contexts(&self) -> Vec<&'static str>;
+    fn get(&self, _target: &str) -> Result<Entity, String> {
+        Err(format!(
+            "{} theme has no contexts",
+            std::any::type_name::<Self>()
+        ))
+    }
+    fn contexts(&self) -> Vec<&'static str> {
+        vec![]
+    }
 }
 
 pub trait DefaultTheme: Clone + Component + UiContext {

--- a/crates/sickle_ui_scaffold/src/theme.rs
+++ b/crates/sickle_ui_scaffold/src/theme.rs
@@ -136,7 +136,7 @@ impl PseudoTheme {
 pub trait UiContext {
     fn get(&self, _target: &str) -> Result<Entity, String> {
         Err(format!(
-            "{} theme has no contexts",
+            "{} has no UI contexts",
             std::any::type_name::<Self>()
         ))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use scroll_interaction::ScrollInteractionPlugin;
 use theme::ThemePlugin;
 use widgets::WidgetsPlugin;
 
+pub use sickle_macros::*;
 pub use sickle_math::*;
 pub use sickle_ui_scaffold::*;
 


### PR DESCRIPTION
I need to make themes, but don't need to use contexts via the `UiContext` trait (I manually set the target entity for custom dynamic styles). Having a default implementation makes it easier to write new themes.