### PR TITLE
Fix drag behavior on macOS for Draggable

### DIFF
--- a/src/resize_interaction.rs
+++ b/src/resize_interaction.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_reflect::Reflect;
+use bevy::ui::RelativeCursorPosition;
 use sickle_math::ease::Ease;
 
 use crate::{
@@ -184,6 +185,7 @@ impl ResizeHandle {
                 ..default()
             },
             Draggable::default(),
+            RelativeCursorPosition::default(),
             ResizeHandle { direction },
         )
     }

--- a/src/widgets/floating_panel.rs
+++ b/src/widgets/floating_panel.rs
@@ -1,4 +1,4 @@
-use bevy::ui::FocusPolicy;
+use bevy::ui::{FocusPolicy, RelativeCursorPosition};
 use bevy::window::PrimaryWindow;
 use bevy::{prelude::*, window::WindowResized};
 use sickle_math::ease::Ease;
@@ -640,6 +640,7 @@ impl FloatingPanel {
             },
             TrackedInteraction::default(),
             Draggable::default(),
+            RelativeCursorPosition::default(),
         )
     }
 
@@ -834,6 +835,7 @@ impl<'w, 's> UiFloatingPanelExt<'w, 's> for UiBuilder<'w, 's, '_, Entity> {
                     FloatingPanelTitle { panel },
                     TrackedInteraction::default(),
                     Draggable::default(),
+                    RelativeCursorPosition::default(),
                 ),
                 |container| {
                     fold_button = container

--- a/src/widgets/scroll_view.rs
+++ b/src/widgets/scroll_view.rs
@@ -1,4 +1,4 @@
-use bevy::{input::mouse::MouseScrollUnit, prelude::*, ui::FocusPolicy};
+use bevy::{input::mouse::MouseScrollUnit, prelude::*, ui::{FocusPolicy, RelativeCursorPosition}};
 use sickle_math::ease::Ease;
 
 use crate::{
@@ -573,6 +573,7 @@ impl ScrollView {
                 ..default()
             },
             Draggable::default(),
+            RelativeCursorPosition::default(),
             Scrollable::default(),
         )
     }

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -1,4 +1,4 @@
-use bevy::{input::mouse::MouseScrollUnit, prelude::*};
+use bevy::{input::mouse::MouseScrollUnit, ui::RelativeCursorPosition, prelude::*};
 use sickle_math::ease::Ease;
 
 use crate::{
@@ -519,6 +519,7 @@ impl Slider {
             },
             SliderDragHandle { slider },
             Draggable::default(),
+            RelativeCursorPosition::default(),
             Scrollable::default(),
         )
     }

--- a/src/widgets/tab_container.rs
+++ b/src/widgets/tab_container.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::system::Command, prelude::*};
+use bevy::{ecs::system::Command, ui::RelativeCursorPosition, prelude::*};
 use sickle_math::ease::Ease;
 
 use crate::{
@@ -794,6 +794,7 @@ impl TabContainer {
                 ..default()
             },
             Draggable::default(),
+            RelativeCursorPosition::default(),
             GenerateContextMenu::default(),
         )
     }


### PR DESCRIPTION
# Objective
Bevy's default behavior with CursorGrab results in macOS users having stuck, halting dragging behavior. However, even with the CursorGrab removed, the dragging behavior on macOS still felt sticky and gunky. This PR makes some small adjustments to drag_interaction.rs and results in smooth drag behavior on macs. Fixes #9 .

## Solution

Removed CursorGrab system from drag_interaction.rs. Added a RelativeCursorPosition component to all widget nodes that have Draggable, and used it as an alternative way to find the cursor position in drag_interaction.rs.

## Testing

Tested on a Mac and a Windows machine, on my project and both sickle_ui examples, simple_editor and docking_zone_splits.