### PR TITLE
Add CursorGrab back with Windows-only run condition

### DIFF
--- a/src/drag_interaction.rs
+++ b/src/drag_interaction.rs
@@ -16,6 +16,7 @@ impl Plugin for DragInteractionPlugin {
                     update_drag_progress,
                     update_drag_state,
                     update_cursor_confinement_from_drag
+                        .run_if(is_windows_os())
                 )
                     .chain()
                     .in_set(DraggableUpdate),
@@ -64,16 +65,15 @@ pub enum DragSource {
     Touch(u64),
 }
 
+/// Returns `cfg!(target_os = "windows")`
+fn is_windows_os() -> impl Condition<()> {
+    IntoSystem::into_system(| mut os_check: Local<bool> | { *os_check = cfg!(target_os = "windows"); *os_check })
+}
+
 fn update_cursor_confinement_from_drag(
     q_draggable: Query<&Draggable, Changed<Draggable>>,
     mut q_window: Query<&mut Window, With<PrimaryWindow>>,
 ) {
-    // CursorGrabMode::Confined has strange behavior outside of Windows.
-    // On macOS, CursorGrabMode::Confined doesn't exist, so Bevy uses CursorGrabMode::Locked instead.
-    if !cfg!(target_os = "windows") {
-        return;
-    }
-
     let Ok(mut window) = q_window.get_single_mut() else {
         return;
     };


### PR DESCRIPTION
## Objective ##
A previous PR addressing a macOS drag bug (#31) removed the CursorGrabMode-setting system. However, some sickle_ui Windows users would like that functionality to return.

## Solution ##
Reverted removal of `update_cursor_confinement_from_drag` system, added `is_windows_os` run condition so it only runs when compiling on Windows.

## Testing ##
Tested both examples on my personal macOS and windows machines to apparent success.