### PR TITLE
StyleBuilder optimizations

### DIFF
--- a/src/widgets/inputs/slider.rs
+++ b/src/widgets/inputs/slider.rs
@@ -421,7 +421,7 @@ impl Slider {
                     .margin(UiRect::left(Val::Px(theme_spacing.gaps.medium)));
 
                 style_builder
-                    .switch_context(Slider::HANDLE.to_string(), None)
+                    .switch_context(Slider::HANDLE, None)
                     .margin(UiRect::top(Val::Px(
                         -theme_spacing.gaps.medium + theme_spacing.borders.extra_small,
                     )));
@@ -467,7 +467,7 @@ impl Slider {
                     .margin(UiRect::all(Val::Px(theme_spacing.gaps.small)));
 
                 style_builder
-                    .switch_context(Slider::HANDLE.to_string(), None)
+                    .switch_context(Slider::HANDLE, None)
                     .margin(UiRect::left(Val::Px(
                         -theme_spacing.gaps.medium + theme_spacing.borders.extra_small,
                     )));
@@ -522,7 +522,7 @@ impl Slider {
             .border_color(colors.accent(Accent::Shadow));
 
         style_builder
-            .switch_context(Slider::HANDLE.to_string(), None)
+            .switch_context(Slider::HANDLE, None)
             .size(Val::Px(theme_spacing.icons.small))
             .border(UiRect::all(Val::Px(theme_spacing.borders.extra_small)))
             .animated()

--- a/src/widgets/layout/floating_panel.rs
+++ b/src/widgets/layout/floating_panel.rs
@@ -695,7 +695,7 @@ impl FloatingPanel {
             .height(Val::Percent(100.));
 
         style_builder
-            .switch_context(FloatingPanel::DRAG_HANDLE.to_string(), None)
+            .switch_context(FloatingPanel::DRAG_HANDLE, None)
             .width(Val::Percent(100.))
             .height(Val::Px(theme_spacing.borders.small * 2.))
             .border(UiRect::bottom(Val::Px(theme_spacing.borders.small)))
@@ -709,7 +709,7 @@ impl FloatingPanel {
             .copy_from(theme_data.interaction_animation);
 
         style_builder
-            .switch_context(FloatingPanel::FOLD_BUTTON.to_string(), None)
+            .switch_context(FloatingPanel::FOLD_BUTTON, None)
             .size(Val::Px(theme_spacing.icons.small))
             .margin(UiRect::all(Val::Px(theme_spacing.gaps.small)))
             .icon(
@@ -727,7 +727,7 @@ impl FloatingPanel {
             .copy_from(theme_data.interaction_animation);
 
         style_builder
-            .switch_context(FloatingPanel::CLOSE_BUTTON.to_string(), None)
+            .switch_context(FloatingPanel::CLOSE_BUTTON, None)
             .size(Val::Px(theme_spacing.icons.small))
             .margin(UiRect::all(Val::Px(theme_spacing.gaps.small)))
             .icon(

--- a/src/widgets/layout/scroll_view.rs
+++ b/src/widgets/layout/scroll_view.rs
@@ -500,7 +500,7 @@ impl ScrollView {
             .padding(UiRect::all(Val::Auto));
 
         style_builder
-            .switch_context(ScrollView::HORIZONTAL_SCROLL_HANDLE.to_string(), None)
+            .switch_context(ScrollView::HORIZONTAL_SCROLL_HANDLE, None)
             .border(UiRect::horizontal(Val::Px(
                 theme_spacing.borders.extra_small,
             )))
@@ -515,7 +515,7 @@ impl ScrollView {
             .copy_from(theme_data.interaction_animation);
 
         style_builder
-            .switch_context(ScrollView::VERTICAL_SCROLL_HANDLE.to_string(), None)
+            .switch_context(ScrollView::VERTICAL_SCROLL_HANDLE, None)
             .border(UiRect::vertical(Val::Px(theme_spacing.borders.extra_small)))
             .border_color(colors.accent(Accent::Shadow))
             .animated()


### PR DESCRIPTION
- Add `StyleBuilder::new_with_capacity` for cases when the number of attributes is known.
- Use `&'static str` for the context ids.