### PR TITLE
PseudoWorldStyleBuilder cleanup

### DIFF
--- a/crates/sickle_ui_scaffold/src/theme.rs
+++ b/crates/sickle_ui_scaffold/src/theme.rs
@@ -67,7 +67,7 @@ pub enum DynamicStyleBuilder<C> {
     ContextStyleBuilder(fn(&mut StyleBuilder, &C, &ThemeData)),
     WorldStyleBuilder(fn(&mut StyleBuilder, Entity, &C, &World)),
     InfoWorldStyleBuilder(
-        fn(&mut StyleBuilder, Entity, &Option<Vec<PseudoState>>, Entity, &C, &World),
+        fn(&mut StyleBuilder, Option<Entity>, &Option<Vec<PseudoState>>, Entity, &C, &World),
     ),
 }
 
@@ -153,7 +153,14 @@ impl<C> PseudoTheme<C> {
 
     pub fn deferred_info_world(
         state: impl Into<Option<Vec<PseudoState>>>,
-        builder: fn(&mut StyleBuilder, Entity, &Option<Vec<PseudoState>>, Entity, &C, &World),
+        builder: fn(
+            &mut StyleBuilder,
+            Option<Entity>,
+            &Option<Vec<PseudoState>>,
+            Entity,
+            &C,
+            &World,
+        ),
     ) -> Self {
         Self {
             state: state.into(),

--- a/crates/sickle_ui_scaffold/src/theme.rs
+++ b/crates/sickle_ui_scaffold/src/theme.rs
@@ -66,7 +66,9 @@ pub enum DynamicStyleBuilder<C> {
     StyleBuilder(fn(&mut StyleBuilder, &ThemeData)),
     ContextStyleBuilder(fn(&mut StyleBuilder, &C, &ThemeData)),
     WorldStyleBuilder(fn(&mut StyleBuilder, Entity, &C, &World)),
-    PseudoWorldStyleBuilder(fn(&mut StyleBuilder, &Option<Vec<PseudoState>>, Entity, &C, &World)),
+    InfoWorldStyleBuilder(
+        fn(&mut StyleBuilder, Entity, &Option<Vec<PseudoState>>, Entity, &C, &World),
+    ),
 }
 
 impl<C> From<StyleBuilder> for DynamicStyleBuilder<C> {
@@ -149,13 +151,13 @@ impl<C> PseudoTheme<C> {
         }
     }
 
-    pub fn deferred_pseudo_world(
+    pub fn deferred_info_world(
         state: impl Into<Option<Vec<PseudoState>>>,
-        builder: fn(&mut StyleBuilder, &Option<Vec<PseudoState>>, Entity, &C, &World),
+        builder: fn(&mut StyleBuilder, Entity, &Option<Vec<PseudoState>>, Entity, &C, &World),
     ) -> Self {
         Self {
             state: state.into(),
-            builder: DynamicStyleBuilder::PseudoWorldStyleBuilder(builder),
+            builder: DynamicStyleBuilder::InfoWorldStyleBuilder(builder),
         }
     }
 

--- a/crates/sickle_ui_scaffold/src/theme.rs
+++ b/crates/sickle_ui_scaffold/src/theme.rs
@@ -66,7 +66,7 @@ pub enum DynamicStyleBuilder<C> {
     StyleBuilder(fn(&mut StyleBuilder, &ThemeData)),
     ContextStyleBuilder(fn(&mut StyleBuilder, &C, &ThemeData)),
     WorldStyleBuilder(fn(&mut StyleBuilder, Entity, &C, &World)),
-    PseudoWorldStyleBuilder(fn(&mut StyleBuilder, Option<&Vec<PseudoState>>, Entity, &C, &World)),
+    PseudoWorldStyleBuilder(fn(&mut StyleBuilder, &Option<Vec<PseudoState>>, Entity, &C, &World)),
 }
 
 impl<C> From<StyleBuilder> for DynamicStyleBuilder<C> {
@@ -98,8 +98,8 @@ impl<C> PseudoTheme<C> {
         }
     }
 
-    pub fn state(&self) -> Option<&Vec<PseudoState>> {
-        self.state.as_ref()
+    pub fn state(&self) -> &Option<Vec<PseudoState>> {
+        &self.state
     }
 
     pub fn builder(&self) -> &DynamicStyleBuilder<C> {
@@ -151,7 +151,7 @@ impl<C> PseudoTheme<C> {
 
     pub fn deferred_pseudo_world(
         state: impl Into<Option<Vec<PseudoState>>>,
-        builder: fn(&mut StyleBuilder, Option<&Vec<PseudoState>>, Entity, &C, &World),
+        builder: fn(&mut StyleBuilder, &Option<Vec<PseudoState>>, Entity, &C, &World),
     ) -> Self {
         Self {
             state: state.into(),

--- a/crates/sickle_ui_scaffold/src/ui_commands.rs
+++ b/crates/sickle_ui_scaffold/src/ui_commands.rs
@@ -369,10 +369,10 @@ where
         // Default -> General (App-wide) -> Specialized (Screen) theming is a reasonable guess.
         // Round to 4, which is the first growth step.
         // TODO: Cache most common theme count in theme data.
-        let mut themes: Vec<(&Theme<C>, Entity)> = Vec::with_capacity(4);
+        let mut themes: Vec<(&Theme<C>, Option<Entity>)> = Vec::with_capacity(4);
         // Add own theme
         if let Some(own_theme) = world.get::<Theme<C>>(entity) {
-            themes.push((own_theme, entity));
+            themes.push((own_theme, Some(entity)));
         }
 
         // Add all ancestor themes
@@ -380,13 +380,13 @@ where
         while let Some(parent) = world.get::<Parent>(current_ancestor) {
             current_ancestor = parent.get();
             if let Some(ancestor_theme) = world.get::<Theme<C>>(current_ancestor) {
-                themes.push((ancestor_theme, current_ancestor));
+                themes.push((ancestor_theme, Some(current_ancestor)));
             }
         }
 
         let default_theme = C::default_theme();
         if let Some(ref default_theme) = default_theme {
-            themes.push((default_theme, entity));
+            themes.push((default_theme, None));
         }
 
         if themes.len() == 0 {
@@ -403,7 +403,7 @@ where
 
         // Assuming we have a base style and two-three pseudo state style is a reasonable guess.
         // TODO: Cache most common pseudo theme count in theme data.
-        let mut pseudo_themes: Vec<(&PseudoTheme<C>, Entity)> =
+        let mut pseudo_themes: Vec<(&PseudoTheme<C>, Option<Entity>)> =
             Vec::with_capacity(themes.len() * 4);
 
         for (theme, source_entity) in &themes {


### PR DESCRIPTION
- `Option<&Vec<PseudoState>>` -> `&Option<Vec<PseudoState>>`. Mistake from earlier PR. With ref on the inside it's harder to do `state == other_state`.
- Add the theme's source entity to `PseudoWorldStyleBuilder`. This gave me a really confusing bug lol, it was trying to find theme data on the wrong entity for an inherited theme.
- Rename to `InfoWorldStyleBuilder`.