### PR TITLE
Fix missing EmbeddedAssetRegistry resource

### DIFF
--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -6,7 +6,7 @@
 mod fonts;
 mod icons;
 
-use bevy::prelude::*;
+use bevy::{asset::io::embedded::EmbeddedAssetRegistry, prelude::*};
 
 use fonts::BuiltInFontsPlugin;
 use icons::BuiltInIconsPlugin;
@@ -15,6 +15,7 @@ pub(crate) struct BuiltInAssetsPlugin;
 
 impl Plugin for BuiltInAssetsPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<EmbeddedAssetRegistry>();
         app.add_plugins((BuiltInFontsPlugin, BuiltInIconsPlugin));
     }
 }


### PR DESCRIPTION
This PR fixes the missing **EmbeddedAssetRegistry** resources, which prevents me from upgrading **sickle_ui** to 0.2.0.

The bug is shown in the attached image:
![image](https://github.com/UmbraLuminosa/sickle_ui/assets/72777913/2bc5d8b0-c7a2-43a0-9fe4-9f8323b30c31)

