### PR TITLE
DefaultTheme shouldn't need to require Clone

### DIFF
--- a/crates/sickle_ui_scaffold/src/theme.rs
+++ b/crates/sickle_ui_scaffold/src/theme.rs
@@ -223,7 +223,7 @@ pub trait UiContext {
     }
 }
 
-pub trait DefaultTheme: Clone + Component + UiContext {
+pub trait DefaultTheme: Sized + Component + UiContext {
     fn default_theme() -> Option<Theme<Self>> {
         None
     }

--- a/crates/sickle_ui_scaffold/src/ui_commands.rs
+++ b/crates/sickle_ui_scaffold/src/ui_commands.rs
@@ -339,7 +339,7 @@ where
     C: DefaultTheme,
 {
     fn apply(self, entity: Entity, world: &mut World) {
-        let context = world.get::<C>(entity).unwrap().clone();
+        let context = world.get::<C>(entity).unwrap();
         let theme_data = world.resource::<ThemeData>().clone();
         let pseudo_states = world.get::<PseudoStates>(entity);
         let empty_pseudo_state = Vec::new();
@@ -411,25 +411,25 @@ where
         let styles: Vec<(Option<Entity>, DynamicStyle)> = pseudo_themes
             .iter()
             .map(
-                |(pseudo_theme, source_entity)| match pseudo_theme.builder().clone() {
+                |(pseudo_theme, source_entity)| match pseudo_theme.builder() {
                     DynamicStyleBuilder::Static(style) => vec![(None, style.clone())],
                     DynamicStyleBuilder::StyleBuilder(builder) => {
                         let mut style_builder = StyleBuilder::new();
                         builder(&mut style_builder, &theme_data);
 
-                        style_builder.convert_with(&context)
+                        style_builder.convert_with(context)
                     }
                     DynamicStyleBuilder::ContextStyleBuilder(builder) => {
                         let mut style_builder = StyleBuilder::new();
                         builder(&mut style_builder, &context, &theme_data);
 
-                        style_builder.convert_with(&context)
+                        style_builder.convert_with(context)
                     }
                     DynamicStyleBuilder::WorldStyleBuilder(builder) => {
                         let mut style_builder = StyleBuilder::new();
                         builder(&mut style_builder, entity, &context, world);
 
-                        style_builder.convert_with(&context)
+                        style_builder.convert_with(context)
                     }
                     DynamicStyleBuilder::InfoWorldStyleBuilder(builder) => {
                         let mut style_builder = StyleBuilder::new();
@@ -442,7 +442,7 @@ where
                             world,
                         );
 
-                        style_builder.convert_with(&context)
+                        style_builder.convert_with(context)
                     }
                 },
             )


### PR DESCRIPTION
It seems possible to avoid this overly restrictive trait bound. In my case, I have a template type that I want to DefaultTheme. A template parameter is of a type that is unused in the type and cannot be Clone for reasons.

```rust
#[derive(Component, Reflect)]
pub(crate) struct ManifestEditor<M>
where
    M: Manifest + EditableManifest,
{
    manifest: String,
    handle: Handle<M::RawManifest>,
    loaded: bool,

    items: Entity,
    props: Entity,
}

impl<M> DefaultTheme for ManifestEditor<M>
where
    M: Manifest + EditableManifest,
{
    fn default_theme() -> Option<Theme<ManifestEditor<M>>> {
        ManifestEditor::<M>::theme().into()
    }
}

impl<M> ManifestEditor<M>
where
    M: Manifest + EditableManifest,
{
    pub const ITEMS: &'static str = "Items";
    pub const PROPS: &'static str = "Props";

    pub fn theme() -> Theme<ManifestEditor<M>> {
        let base_theme = PseudoTheme::deferred(None, ManifestEditor::<M>::primary_style);
        Theme::new(vec![base_theme])
    }

    fn primary_style(style_builder: &mut StyleBuilder, theme_data: &ThemeData) {}
}
```
It seems reasonable for this to be Sized. I tested this locally and the examples all work fine with this change.