### PR TITLE
Fix minor spelling error

### DIFF
--- a/.vscode/sickle_ui.code-snippets
+++ b/.vscode/sickle_ui.code-snippets
@@ -171,7 +171,7 @@
 			"		match target {",
 			"			${1:MyWidget}::LABEL => Ok(self.label),",
 			"			_ => Err(format!(",
-			"				\"{} doesn't exists for ${1:MyWidget}. Possible contexts: {:?}\",",
+			"				\"{} doesn't exist for ${1:MyWidget}. Possible contexts: {:?}\",",
 			"				target,",
 			"				self.contexts()",
 			"			)),",

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ impl UiContext for MyWidget {
         match target {
             MyWidget::LABEL => Ok(self.label),
             _ => Err(format!(
-                "{} doesn't exists for MyWidget. Possible contexts: {:?}",
+                "{} doesn't exist for MyWidget. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),
@@ -809,7 +809,7 @@ impl UiContext for MyWidget {
         match target {
             MyWidget::LABEL => Ok(self.label),
             _ => Err(format!(
-                "{} doesn't exists for MyWidget. Possible contexts: {:?}",
+                "{} doesn't exist for MyWidget. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/dev_panels/entity_component_list.rs
+++ b/src/dev_panels/entity_component_list.rs
@@ -116,7 +116,7 @@ impl UiContext for EntityComponentTag {
         match target {
             EntityComponentTag::LABEL => Ok(self.label),
             _ => Err(format!(
-                "{} doesn't exists for EntityComponentTag. Possible contexts: {:?}",
+                "{} doesn't exist for EntityComponentTag. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/inputs/checkbox.rs
+++ b/src/widgets/inputs/checkbox.rs
@@ -76,7 +76,7 @@ impl UiContext for Checkbox {
             Checkbox::CHECKMARK => Ok(self.checkmark),
             Checkbox::LABEL => Ok(self.label),
             _ => Err(format!(
-                "{} doesn't exists for Checkbox. Possible contexts: {:?}",
+                "{} doesn't exist for Checkbox. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/inputs/dropdown.rs
+++ b/src/widgets/inputs/dropdown.rs
@@ -201,7 +201,7 @@ impl UiContext for DropdownOption {
         match target {
             DropdownOption::LABEL => Ok(self.label),
             _ => Err(format!(
-                "{} doesn't exists for DropdownOption. Possible contexts: {:?}",
+                "{} doesn't exist for DropdownOption. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),
@@ -321,7 +321,7 @@ impl UiContext for Dropdown {
             Dropdown::SCROLL_VIEW => Ok(self.scroll_view),
             Dropdown::SCROLL_VIEW_CONTENT => Ok(self.scroll_view_content),
             _ => Err(format!(
-                "{} doesn't exists for Dropdown. Possible contexts: {:?}",
+                "{} doesn't exist for Dropdown. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/inputs/radio_group.rs
+++ b/src/widgets/inputs/radio_group.rs
@@ -182,7 +182,7 @@ impl UiContext for RadioButton {
             RadioButton::RADIOMARK => Ok(self.radiomark),
             RadioButton::LABEL => Ok(self.label),
             _ => Err(format!(
-                "{} doesn't exists for RadioButton. Possible contexts: {:?}",
+                "{} doesn't exist for RadioButton. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/inputs/slider.rs
+++ b/src/widgets/inputs/slider.rs
@@ -333,7 +333,7 @@ impl UiContext for Slider {
             Slider::READOUT_CONTAINER => Ok(self.readout_container),
             Slider::READOUT => Ok(self.readout),
             _ => Err(format!(
-                "{} doesn't exists for Slider. Possible contexts: {:?}",
+                "{} doesn't exist for Slider. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/layout/floating_panel.rs
+++ b/src/widgets/layout/floating_panel.rs
@@ -587,7 +587,7 @@ impl UiContext for FloatingPanel {
             FloatingPanel::CLOSE_BUTTON => Ok(self.close_button),
             FloatingPanel::CONTENT_VIEW => Ok(self.content_view),
             _ => Err(format!(
-                "{} doesn't exists for FloatingPanel. Possible contexts: {:?}",
+                "{} doesn't exist for FloatingPanel. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/layout/foldable.rs
+++ b/src/widgets/layout/foldable.rs
@@ -105,7 +105,7 @@ impl UiContext for Foldable {
             Foldable::BUTTON_LABEL => Ok(self.label),
             Foldable::CONTAINER => Ok(self.container),
             _ => Err(format!(
-                "{} doesn't exists for Foldable. Possible contexts: {:?}",
+                "{} doesn't exist for Foldable. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/layout/resize_handles.rs
+++ b/src/widgets/layout/resize_handles.rs
@@ -203,7 +203,7 @@ impl UiContext for ResizeHandles {
             ResizeHandles::HANDLE_WEST => Ok(self.handle_west),
             ResizeHandles::HANDLE_NORTH_WEST => Ok(self.handle_north_west),
             _ => Err(format!(
-                "{} doesn't exists for ResizeHandles. Possible contexts: {:?}",
+                "{} doesn't exist for ResizeHandles. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/layout/scroll_view.rs
+++ b/src/widgets/layout/scroll_view.rs
@@ -404,7 +404,7 @@ impl UiContext for ScrollView {
             ScrollView::VERTICAL_SCROLL_BAR => Ok(self.vertical_scroll_bar),
             ScrollView::VERTICAL_SCROLL_HANDLE => Ok(self.vertical_scroll_bar_handle),
             _ => Err(format!(
-                "{} doesn't exists for ScrollView. Possible contexts: {:?}",
+                "{} doesn't exist for ScrollView. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/layout/sized_zone.rs
+++ b/src/widgets/layout/sized_zone.rs
@@ -607,7 +607,7 @@ impl UiContext for SizedZone {
         match target {
             SizedZone::RESIZE_HANDLES => Ok(self.resize_handles),
             _ => Err(format!(
-                "{} doesn't exists for SizedZone. Possible contexts: {:?}",
+                "{} doesn't exist for SizedZone. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/layout/tab_container.rs
+++ b/src/widgets/layout/tab_container.rs
@@ -671,7 +671,7 @@ impl UiContext for Tab {
             Tab::LABEL => Ok(self.label),
             Tab::PANEL => Ok(self.panel),
             _ => Err(format!(
-                "{} doesn't exists for Tab. Possible contexts: {:?}",
+                "{} doesn't exist for Tab. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),
@@ -960,7 +960,7 @@ impl UiContext for TabContainer {
         match target {
             TabContainer::TAB_BAR => Ok(self.bar),
             _ => Err(format!(
-                "{} doesn't exists for TabContainer. Possible contexts: {:?}",
+                "{} doesn't exist for TabContainer. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/menus/menu.rs
+++ b/src/widgets/menus/menu.rs
@@ -184,7 +184,7 @@ impl UiContext for Menu {
             Menu::LABEL => Ok(self.label),
             Menu::CONTAINER => Ok(self.container),
             _ => Err(format!(
-                "{} doesn't exists for Menu. Possible contexts: {:?}",
+                "{} doesn't exist for Menu. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/menus/menu_item.rs
+++ b/src/widgets/menus/menu_item.rs
@@ -128,7 +128,7 @@ impl UiContext for MenuItem {
             MenuItem::SHORTCUT => Ok(self.shortcut),
             MenuItem::TRAILING_ICON => Ok(self.trailing),
             _ => Err(format!(
-                "{} doesn't exists for MenuItem. Possible contexts: {:?}",
+                "{} doesn't exist for MenuItem. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/menus/submenu.rs
+++ b/src/widgets/menus/submenu.rs
@@ -339,7 +339,7 @@ impl UiContext for Submenu {
             MenuItem::TRAILING_ICON => Ok(self.trailing),
             Submenu::MENU_CONTAINER => Ok(self.container),
             _ => Err(format!(
-                "{} doesn't exists for MenuItem. Possible contexts: {:?}",
+                "{} doesn't exist for MenuItem. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),

--- a/src/widgets/menus/toggle_menu_item.rs
+++ b/src/widgets/menus/toggle_menu_item.rs
@@ -148,7 +148,7 @@ impl UiContext for ToggleMenuItem {
             MenuItem::SHORTCUT => Ok(self.shortcut),
             MenuItem::TRAILING_ICON => Ok(self.trailing),
             _ => Err(format!(
-                "{} doesn't exists for MenuItem. Possible contexts: {:?}",
+                "{} doesn't exist for MenuItem. Possible contexts: {:?}",
                 target,
                 self.contexts()
             )),


### PR DESCRIPTION
The same "doesn't exists" spelling error appears throughout the code base, probably proliferated itself through the VSCode snippet. I searched and replaced all occurrences.