### PR TITLE
Remove reliance on bevy default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,12 @@ sickle_math = { path = "crates/sickle_math", version = "0.2.1" }
 sickle_macros = { path = "crates/sickle_macros", version = "0.2.1" }
 sickle_ui_scaffold = { path = "crates/sickle_ui_scaffold", version = "0.2.1" }
 
-bevy = { version = "0.14" }
-bevy_reflect = { version = "0.14" }
-bevy_ecs_macros = { version = "0.14" }
+bevy = { version = "0.14", default-features = false, features = [
+    "bevy_asset",
+    "bevy_color",
+    "bevy_text",
+    "bevy_ui",
+    "bevy_winit",
+] }
 
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ sickle_ui_scaffold = { path = "crates/sickle_ui_scaffold", version = "0.2.1" }
 bevy = { version = "0.14", default-features = false, features = [
     "bevy_asset",
     "bevy_color",
+    "bevy_state",
     "bevy_text",
     "bevy_ui",
     "bevy_winit",

--- a/crates/sickle_ui_scaffold/Cargo.toml
+++ b/crates/sickle_ui_scaffold/Cargo.toml
@@ -15,6 +15,8 @@ sickle_math = { path = "../sickle_math", version = "0.2.1" }
 sickle_macros = { path = "../sickle_macros", version = "0.2.1" }
 
 bevy = { version = "0.14", default-features = true, features = [
+    "bevy_asset",
+    "bevy_color",
     "bevy_state",
     "bevy_text",
     "bevy_ui",

--- a/crates/sickle_ui_scaffold/Cargo.toml
+++ b/crates/sickle_ui_scaffold/Cargo.toml
@@ -14,6 +14,10 @@ dev = ["bevy/dynamic_linking"]
 sickle_math = { path = "../sickle_math", version = "0.2.1" }
 sickle_macros = { path = "../sickle_macros", version = "0.2.1" }
 
-bevy = { version = "0.14", default-features = false }
-bevy_reflect = { version = "0.14" }
+bevy = { version = "0.14", default-features = true, features = [
+    "bevy_state",
+    "bevy_text",
+    "bevy_ui",
+    "bevy_winit",
+] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sickle_ui_scaffold/src/drag_interaction.rs
+++ b/crates/sickle_ui_scaffold/src/drag_interaction.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy::reflect::Reflect;
 use bevy::ui::RelativeCursorPosition;
 use bevy::window::{CursorGrabMode, PrimaryWindow};
 

--- a/crates/sickle_ui_scaffold/src/drag_interaction.rs
+++ b/crates/sickle_ui_scaffold/src/drag_interaction.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
+use bevy::reflect::Reflect;
 use bevy::ui::RelativeCursorPosition;
 use bevy::window::{CursorGrabMode, PrimaryWindow};
-use bevy_reflect::Reflect;
 
 use crate::flux_interaction::{FluxInteraction, FluxInteractionUpdate};
 

--- a/crates/sickle_ui_scaffold/src/flux_interaction.rs
+++ b/crates/sickle_ui_scaffold/src/flux_interaction.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, ops::Add, time::Duration};
 
-use bevy::{prelude::*, reflect::Reflect, time::Stopwatch, utils::HashMap};
+use bevy::{prelude::*, time::Stopwatch, utils::HashMap};
 
 pub struct FluxInteractionPlugin;
 

--- a/crates/sickle_ui_scaffold/src/flux_interaction.rs
+++ b/crates/sickle_ui_scaffold/src/flux_interaction.rs
@@ -1,7 +1,6 @@
 use std::{cmp::Ordering, ops::Add, time::Duration};
 
-use bevy::{prelude::*, time::Stopwatch, utils::HashMap};
-use bevy_reflect::Reflect;
+use bevy::{prelude::*, reflect::Reflect, time::Stopwatch, utils::HashMap};
 
 pub struct FluxInteractionPlugin;
 

--- a/crates/sickle_ui_scaffold/src/resize_interaction.rs
+++ b/crates/sickle_ui_scaffold/src/resize_interaction.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy_reflect::Reflect;
 use bevy::ui::RelativeCursorPosition;
 use sickle_math::ease::Ease;
 

--- a/src/widgets/layout/resize_handles.rs
+++ b/src/widgets/layout/resize_handles.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use bevy::ui::RelativeCursorPosition;
-use bevy_reflect::Reflect;
 
 use sickle_ui_scaffold::{prelude::*, ui_commands::SetCursorExt};
 


### PR DESCRIPTION
Hi! New contributing to this repo, so I hope you are OK with me submitting a PR before an issue or anything like that.

I was investigating whether sickle_ui could remove its reliance on bevy's default-features and found a few areas of cleanup in the meantime. Since all the examples seem to run fine, I thought I would submit my work here for your review. Feel free to treat it as a suggestion, or let me know what you'd like me to change.

Changes include:
- remove `bevy_reflect` and `bevy_ecs_macros` imports from crates with an existing `bevy` import
- set `default-features = false` for all bevy imports
- adds bevy features `bevy_asset`, `bevy_color`, `bevy_state`, `bevy_text`, `bevy_ui`, and `bevy_winit` (<-- this one probably is only needed in dev-dependencies to run examples but I doubt any users are replacing it in practice anyway) to relevant packages

`bevy_ui` pulls in a lot of the required features, but I thought it best to repeat the requirement for those features, in order to be a little defensive.