### PR TITLE
add fontsource to setfont

### DIFF
--- a/crates/sickle_ui_scaffold/src/ui_style/generated.rs
+++ b/crates/sickle_ui_scaffold/src/ui_style/generated.rs
@@ -11,7 +11,7 @@ use super::{
         CustomInteractiveStyleAttribute, CustomStaticStyleAttribute, InteractiveVals,
     },
     builder::{AnimatedStyleBuilder, InteractiveStyleBuilder, StyleBuilder},
-    manual::{ImageSource, SetAbsolutePositionExt, SetFluxInteractionExt, SetImageExt},
+    manual::{FontSource, ImageSource, SetAbsolutePositionExt, SetFluxInteractionExt, SetImageExt},
     AnimatedVals, LockedStyleAttributes, LogicalEq, TrackedStyleState, UiStyle, UiStyleUnchecked,
 };
 
@@ -208,7 +208,7 @@ enum _StyleAttributes {
     #[skip_lockable_enum]
     #[skip_enity_command]
     Font {
-        font: String,
+        font: FontSource,
     },
     #[skip_lockable_enum]
     #[skip_enity_command]

--- a/crates/sickle_ui_scaffold/src/ui_style/manual.rs
+++ b/crates/sickle_ui_scaffold/src/ui_style/manual.rs
@@ -609,10 +609,37 @@ impl EntityCommand for SetIcon {
     }
 }
 
+#[derive(Clone, Debug)]
+pub enum FontSource {
+    Path(String),
+    Handle(Handle<Font>),
+}
+
+impl Default for FontSource {
+    fn default() -> Self {
+        Self::Handle(Handle::default())
+    }
+}
+
+impl From<&str> for FontSource {
+    fn from(path: &str) -> Self {
+        Self::Path(path.to_string())
+    }
+}
+
+impl From<String> for FontSource {
+    fn from(path: String) -> Self {
+        Self::Path(path)
+    }
+}
+
 // TODO: Update these once font / text handling improves
 impl EntityCommand for SetFont {
     fn apply(self, entity: Entity, world: &mut World) {
-        let font = world.resource::<AssetServer>().load(self.font);
+        let font = match self.font {
+            FontSource::Path(path) => world.resource::<AssetServer>().load(path),
+            FontSource::Handle(handle) => handle,
+        };
 
         let Some(mut text) = world.get_mut::<Text>(entity) else {
             warn!(


### PR DESCRIPTION
We store fonts in different ways, usually in resources, since we load it in different ways, not only through the asset loaders. 

this enables us to use the handles either way