### PR TITLE
Draft/Idea:  Add generic marker to UiStyle

### DIFF
--- a/crates/sickle_macros/src/style_commands.rs
+++ b/crates/sickle_macros/src/style_commands.rs
@@ -344,7 +344,7 @@ fn prepare_static_style_attribute(
         }
 
         impl StaticStyleAttribute {
-            pub fn apply(&self, ui_style: &mut UiStyle) {
+            pub fn apply(&self, ui_style: &mut UiStyle<()>) {
                 match self {
                     #(#apply_variants)*
                     Self::Custom(callback) => {
@@ -402,7 +402,7 @@ fn prepare_interactive_style_attribute(
                 }
             }
 
-            pub fn apply(&self, flux_interaction: FluxInteraction, ui_style: &mut UiStyle) {
+            pub fn apply(&self, flux_interaction: FluxInteraction, ui_style: &mut UiStyle<()>) {
                 match self {
                     Self::Custom(callback) => {
                         ui_style
@@ -471,7 +471,7 @@ fn prepare_animated_style_attribute(
             pub fn apply(
                 &self,
                 current_state: &AnimationState,
-                ui_style: &mut UiStyle,
+                ui_style: &mut UiStyle<()>,
             ) {
                 match self {
                     Self::Custom(callback) => {
@@ -762,7 +762,7 @@ fn to_ui_style_extensions(style_attribute: &StyleAttribute) -> proc_macro2::Toke
             fn #target_attr(&mut self, #target_attr: #target_type) -> &mut Self;
         }
 
-        impl #extension_ident for UiStyle<'_> {
+        impl #extension_ident for UiStyle<'_, ()> {
             fn #target_attr(&mut self, #target_attr: #target_type) -> &mut Self {
                 self.entity_commands().add(#cmd_struct_ident {
                     #target_attr,

--- a/crates/sickle_macros/src/style_commands.rs
+++ b/crates/sickle_macros/src/style_commands.rs
@@ -344,7 +344,7 @@ fn prepare_static_style_attribute(
         }
 
         impl StaticStyleAttribute {
-            pub fn apply(&self, ui_style: &mut UiStyle<()>) {
+            pub fn apply<T>(&self, ui_style: &mut UiStyle<T>) {
                 match self {
                     #(#apply_variants)*
                     Self::Custom(callback) => {
@@ -402,7 +402,7 @@ fn prepare_interactive_style_attribute(
                 }
             }
 
-            pub fn apply(&self, flux_interaction: FluxInteraction, ui_style: &mut UiStyle<()>) {
+            pub fn apply<T>(&self, flux_interaction: FluxInteraction, ui_style: &mut UiStyle<T>) {
                 match self {
                     Self::Custom(callback) => {
                         ui_style
@@ -468,10 +468,10 @@ fn prepare_animated_style_attribute(
                 }
             }
 
-            pub fn apply(
+            pub fn apply<T>(
                 &self,
                 current_state: &AnimationState,
-                ui_style: &mut UiStyle<()>,
+                ui_style: &mut UiStyle<T>,
             ) {
                 match self {
                     Self::Custom(callback) => {
@@ -762,7 +762,7 @@ fn to_ui_style_extensions(style_attribute: &StyleAttribute) -> proc_macro2::Toke
             fn #target_attr(&mut self, #target_attr: #target_type) -> &mut Self;
         }
 
-        impl #extension_ident for UiStyle<'_, ()> {
+        impl<T> #extension_ident for UiStyle<'_, T> {
             fn #target_attr(&mut self, #target_attr: #target_type) -> &mut Self {
                 self.entity_commands().add(#cmd_struct_ident {
                     #target_attr,

--- a/crates/sickle_ui_scaffold/src/ui_builder.rs
+++ b/crates/sickle_ui_scaffold/src/ui_builder.rs
@@ -99,9 +99,14 @@ impl UiBuilder<'_, Entity> {
     ///     }
     /// }
     /// ```
-    pub fn style(&mut self) -> UiStyle {
+    pub fn style(&mut self) -> UiStyle<()> {
         let entity = self.id();
         self.commands().style(entity)
+    }
+    /// This allows for the creation of special style commands, for example if you have created a widget
+    pub fn style_typed<T>(&mut self) -> UiStyle<T> {
+        let entity = self.id();
+        self.commands().style_typed::<T>(entity)
     }
 
     /// Same as [`UiBuilder<'_, Entity>::style()`], except style commands bypass possible attribute locks.

--- a/crates/sickle_ui_scaffold/src/ui_style/manual.rs
+++ b/crates/sickle_ui_scaffold/src/ui_style/manual.rs
@@ -141,7 +141,7 @@ pub trait SetImageExt {
     fn image(&mut self, source: ImageSource) -> &mut Self;
 }
 
-impl SetImageExt for UiStyle<'_> {
+impl SetImageExt for UiStyle<'_, ()> {
     fn image(&mut self, source: ImageSource) -> &mut Self {
         self.commands.add(SetImage {
             source,
@@ -284,7 +284,7 @@ pub trait SetFluxInteractionExt {
     fn flux_interaction_enabled(&mut self, enabled: bool) -> &mut Self;
 }
 
-impl SetFluxInteractionExt for UiStyle<'_> {
+impl SetFluxInteractionExt for UiStyle<'_, ()> {
     fn disable_flux_interaction(&mut self) -> &mut Self {
         self.commands.add(SetFluxInteractionEnabled {
             enabled: false,
@@ -348,7 +348,7 @@ pub trait SetNodeShowHideExt {
     fn render(&mut self, render: bool) -> &mut Self;
 }
 
-impl SetNodeShowHideExt for UiStyle<'_> {
+impl SetNodeShowHideExt for UiStyle<'_, ()> {
     fn show(&mut self) -> &mut Self {
         self.commands
             .add(SetVisibility {
@@ -520,7 +520,7 @@ pub trait SetAbsolutePositionExt {
     fn absolute_position(&mut self, position: Vec2) -> &mut Self;
 }
 
-impl SetAbsolutePositionExt for UiStyle<'_> {
+impl SetAbsolutePositionExt for UiStyle<'_, ()> {
     fn absolute_position(&mut self, position: Vec2) -> &mut Self {
         self.commands.add(SetAbsolutePosition {
             absolute_position: position,
@@ -755,7 +755,7 @@ pub trait SetLockedAttributeExt {
     fn lock_attribute(&mut self, attribute: LockableStyleAttribute) -> &mut Self;
 }
 
-impl SetLockedAttributeExt for UiStyle<'_> {
+impl SetLockedAttributeExt for UiStyle<'_, ()> {
     fn lock_attribute(&mut self, attribute: LockableStyleAttribute) -> &mut Self {
         self.commands.add(SetLockedAttribute {
             attribute,

--- a/crates/sickle_ui_scaffold/src/ui_style/manual.rs
+++ b/crates/sickle_ui_scaffold/src/ui_style/manual.rs
@@ -141,7 +141,7 @@ pub trait SetImageExt {
     fn image(&mut self, source: ImageSource) -> &mut Self;
 }
 
-impl SetImageExt for UiStyle<'_, ()> {
+impl<T> SetImageExt for UiStyle<'_, T> {
     fn image(&mut self, source: ImageSource) -> &mut Self {
         self.commands.add(SetImage {
             source,
@@ -284,7 +284,7 @@ pub trait SetFluxInteractionExt {
     fn flux_interaction_enabled(&mut self, enabled: bool) -> &mut Self;
 }
 
-impl SetFluxInteractionExt for UiStyle<'_, ()> {
+impl<T> SetFluxInteractionExt for UiStyle<'_, T> {
     fn disable_flux_interaction(&mut self) -> &mut Self {
         self.commands.add(SetFluxInteractionEnabled {
             enabled: false,
@@ -348,7 +348,7 @@ pub trait SetNodeShowHideExt {
     fn render(&mut self, render: bool) -> &mut Self;
 }
 
-impl SetNodeShowHideExt for UiStyle<'_, ()> {
+impl<T> SetNodeShowHideExt for UiStyle<'_, T> {
     fn show(&mut self) -> &mut Self {
         self.commands
             .add(SetVisibility {
@@ -520,7 +520,7 @@ pub trait SetAbsolutePositionExt {
     fn absolute_position(&mut self, position: Vec2) -> &mut Self;
 }
 
-impl SetAbsolutePositionExt for UiStyle<'_, ()> {
+impl<T> SetAbsolutePositionExt for UiStyle<'_, T> {
     fn absolute_position(&mut self, position: Vec2) -> &mut Self {
         self.commands.add(SetAbsolutePosition {
             absolute_position: position,
@@ -755,7 +755,7 @@ pub trait SetLockedAttributeExt {
     fn lock_attribute(&mut self, attribute: LockableStyleAttribute) -> &mut Self;
 }
 
-impl SetLockedAttributeExt for UiStyle<'_, ()> {
+impl<T> SetLockedAttributeExt for UiStyle<'_, T> {
     fn lock_attribute(&mut self, attribute: LockableStyleAttribute) -> &mut Self {
         self.commands.add(SetLockedAttribute {
             attribute,

--- a/examples/widget.rs
+++ b/examples/widget.rs
@@ -1,0 +1,212 @@
+use std::marker::PhantomData;
+
+use bevy::{color::palettes::css, ecs::system::EntityCommand, prelude::*};
+use sickle_ui::{prelude::*, SickleUiPlugin};
+
+pub trait SetTitledLabelValueCommand {
+    fn label(&mut self, text: impl Into<String>) -> &mut Self;
+    fn title(&mut self, text: impl Into<String>) -> &mut Self;
+    fn label_font_size(&mut self, size: f32) -> &mut Self;
+}
+
+impl SetTitledLabelValueCommand for UiStyle<'_, TitleLabel> {
+    fn label(&mut self, text: impl Into<String>) -> &mut Self {
+        let v = SetTitledLabelProperties::Label(text.into());
+        self.entity_commands().add(v);
+        self
+    }
+    fn title(&mut self, text: impl Into<String>) -> &mut Self {
+        let v = SetTitledLabelProperties::Title(text.into());
+        self.entity_commands().add(v);
+        self
+    }
+    fn label_font_size(&mut self, size: f32) -> &mut Self {
+        let v = SetTitledLabelProperties::LabelFontSize(size);
+        self.entity_commands().add(v);
+        self
+    }
+}
+
+pub enum SetTitledLabelProperties<T: Component> {
+    Label(String),
+    Title(String),
+    LabelFontSize(f32),
+    Noop(PhantomData<T>),
+}
+
+impl EntityCommand for SetTitledLabelProperties<TitleLabel> {
+    fn apply(self, id: Entity, world: &mut World) {
+        let Some(me) = world.get::<TitleLabel>(id) else {
+            return;
+        };
+        match self {
+            SetTitledLabelProperties::Label(label) => {
+                let e = me.label.clone();
+                if let Some(mut text) = world.entity_mut(e).get_mut::<Text>() {
+                    if let Some(section) = text.sections.first_mut() {
+                        section.value = label;
+                    }
+                }
+            }
+            SetTitledLabelProperties::Title(title) => {
+                let e = me.title.clone();
+                if let Some(mut text) = world.entity_mut(e).get_mut::<Text>() {
+                    if let Some(section) = text.sections.first_mut() {
+                        section.value = title;
+                    }
+                }
+            }
+            SetTitledLabelProperties::LabelFontSize(size) => {
+                let e = me.label.clone();
+                if let Some(mut text) = world.entity_mut(e).get_mut::<Text>() {
+                    if let Some(section) = text.sections.first_mut() {
+                        section.style.font_size = size;
+                    }
+                }
+            }
+            SetTitledLabelProperties::Noop(_) => todo!(),
+        }
+    }
+}
+
+#[derive(Component)]
+pub struct TitleLabel {
+    #[allow(unused)]
+    title: Entity,
+    label: Entity,
+}
+
+pub trait TitledLabelExt {
+    fn titled_label(
+        &mut self,
+        title: impl Into<String>,
+        label: impl Into<String>,
+    ) -> UiBuilder<Entity>;
+}
+
+impl TitledLabelExt for UiBuilder<'_, Entity> {
+    fn titled_label(
+        &mut self,
+        title: impl Into<String>,
+        label: impl Into<String>,
+    ) -> UiBuilder<Entity> {
+        let title: String = title.into();
+
+        let mut t = Entity::PLACEHOLDER;
+        let mut l = Entity::PLACEHOLDER;
+        let mut builder = self.container(
+            (
+                NodeBundle::default(),
+                Name::new(format!("TitledLabel: {title}")),
+            ),
+            |container| {
+                container.style().flex_direction(FlexDirection::Column);
+
+                t = container
+                    .label(LabelConfig::from(title))
+                    .style()
+                    .align_self(AlignSelf::Start)
+                    .font_size(25.)
+                    .font_color(css::GRAY.into())
+                    .id();
+
+                l = container
+                    .label(LabelConfig::from(label))
+                    .style()
+                    .align_self(AlignSelf::Start)
+                    .font_size(20.)
+                    .font_color(css::GREEN.into())
+                    .id();
+            },
+        );
+        builder.insert(TitleLabel { title: t, label: l });
+        builder
+    }
+}
+#[derive(Component)]
+pub struct Root {
+    pub label_one: Entity,
+    pub label_two: Entity,
+}
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            title: "Sickle UI -  Simple Editor".into(),
+            resolution: (1280., 720.).into(),
+            ..default()
+        }),
+        ..default()
+    }))
+    .add_plugins(SickleUiPlugin)
+    .add_systems(Startup, setup)
+    .add_systems(Update, modify_labels)
+    .run();
+}
+
+fn modify_labels(
+    mut commands: Commands,
+    q: Query<&Root>,
+    time: Res<Time>,
+    mut frames: Local<usize>,
+) {
+    let root_node = q.single();
+
+    *frames += 1;
+
+    commands.style(root_node.label_one);
+    // this does not exist, since I have not specifed that this is a TitledLabel and thus it would not compile
+    // preventing this simple bug at compile time
+
+    // .label(time.elapsed_seconds().to_string())
+
+    commands
+        // gets the style parameter for the container node
+        .style_typed::<TitleLabel>(root_node.label_two)
+        // this is only available on the UiStyle<'_, TitleLabel> that I get from the typed style, because it
+        // makes assumptions on the components on this entity.
+        .label(frames.to_string())
+        // unfortunatly this wont work, since the font_size will try and set the font of the container node of the
+        // of the label widget, but if I wished, I can create a custom command for this type of "widget"
+        .font_size((*frames % 100 + 10) as f32)
+        // font size label
+        .label_font_size((*frames % 100 + 10) as f32);
+}
+
+fn setup(mut commands: Commands) {
+    // The main camera which will render UI
+    commands.spawn((Camera3dBundle {
+        camera: Camera {
+            order: 1,
+            clear_color: Color::BLACK.into(),
+            ..default()
+        },
+        transform: Transform::from_translation(Vec3::new(0., 30., 0.))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    },));
+
+    // Use the UI builder with plain bundles and direct setting of bundle props
+
+    let mut label_one = Entity::PLACEHOLDER;
+    let mut label_two = Entity::PLACEHOLDER;
+    commands
+        .ui_builder(UiRoot)
+        .container(NodeBundle::default(), |root| {
+            root.style()
+                .width(Val::Px(100.))
+                .height(Val::Px(100.))
+                .flex_direction(FlexDirection::Column)
+                .justify_content(JustifyContent::Center)
+                .align_content(AlignContent::Center);
+
+            label_one = root.titled_label("Elapsed Time", "0").id();
+            label_two = root.titled_label("Frames", "0").id();
+        })
+        .insert(Root {
+            label_one,
+            label_two,
+        });
+}


### PR DESCRIPTION
to be able to implement traits on type specific versions of UiStyle. 

I added an example where I added TitledLables, which is just two text boxes in a container. 

Currently its very limited, since i am still only able to style the entites i can reach from the query. I would want to be able to in the TitledLabel widget, add a widget underneath, and from the styles() at the root, be able to trigger stuff on the child widget simply. 

but I believe its a good way to be able to go further down 
I just wish I could find a good way to nest deeper into a hierarchy, and modify the correct entity somehow.

I am thinking of some way of creating "typed entities" that I can store onto components, and thus traverse easier, and when storing the value on the component, having the type of the entity available there, as well as getting the correct UiStyle...

