### PR TITLE
Added nested Widget creation and modification example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,4 @@ serde_json = "1.0.127"
 
 [dev-dependencies]
 bevy = { version = "*", default-features = false, features = ["bevy_gltf"] }
+extension-trait = "1.0"

--- a/crates/sickle_ui_scaffold/src/ui_builder.rs
+++ b/crates/sickle_ui_scaffold/src/ui_builder.rs
@@ -123,6 +123,8 @@ impl<T: UiBuilderGetId> UiBuilder<'_, T> {
         self.commands().style(entity)
     }
 
+    /// This allows for modification of style, and also returning the UiBuilder with context
+    /// intact for further processing
     pub fn style_inplace(&mut self, style_fn: impl FnOnce(&mut UiStyle)) -> &mut Self {
         let entity = self.id();
         let mut style = self.commands().style(entity);

--- a/crates/sickle_ui_scaffold/src/ui_builder.rs
+++ b/crates/sickle_ui_scaffold/src/ui_builder.rs
@@ -96,6 +96,17 @@ impl<T: UiBuilderGetId> UiBuilder<'_, T> {
         self.commands().entity(entity)
     }
 
+    /// This allows for using the `EntityCommands` of the builder, and also returning the UiBuilder with context
+    /// intact for further processing
+    pub fn entity_commands_inplace(
+        &mut self,
+        entity_commands_fn: impl FnOnce(&mut EntityCommands),
+    ) -> &mut Self {
+        let mut ec = self.entity_commands();
+        entity_commands_fn(&mut ec);
+        self
+    }
+
     /// Styling commands for UI Nodes
     ///
     /// `sickle_ui` exposes functions for all standard bevy styleable attributes.

--- a/crates/sickle_ui_scaffold/src/ui_builder.rs
+++ b/crates/sickle_ui_scaffold/src/ui_builder.rs
@@ -175,7 +175,7 @@ impl<T: UiBuilderGetId> UiBuilder<'_, T> {
 /// Implementations that are useful for creating nested widgets
 impl<T> UiBuilder<'_, (Entity, T)> {
     /// The extension content of the UiBuilder
-    pub fn content(&self) -> &T {
+    pub fn context_data(&self) -> &T {
         &self.context().1
     }
 }

--- a/examples/widget.rs
+++ b/examples/widget.rs
@@ -1,0 +1,222 @@
+use bevy::{color::palettes::css, ecs::system::EntityCommand, prelude::*};
+use sickle_ui::{prelude::*, SickleUiPlugin};
+
+// Not necessary, but very nice for this kind of "widget" work
+use extension_trait::extension_trait;
+#[extension_trait]
+/// Spawning function on general uibuilder
+impl TitledLabelExt for UiBuilder<'_, Entity> {
+    fn titled_label(
+        &mut self,
+        title: impl Into<String>,
+        label: impl Into<String>,
+    ) -> UiBuilder<Entity> {
+        let title: String = title.into();
+
+        let mut t = Entity::PLACEHOLDER;
+        let mut l = Entity::PLACEHOLDER;
+        let mut builder = self.container(
+            (
+                NodeBundle::default(),
+                Name::new(format!("TitledLabel: {title}")),
+            ),
+            |container| {
+                container.style().flex_direction(FlexDirection::Column);
+
+                t = container
+                    .label(LabelConfig::from(title))
+                    .style()
+                    .align_self(AlignSelf::Start)
+                    .font_size(25.)
+                    .font_color(css::GRAY.into())
+                    .id();
+
+                l = container
+                    .label(LabelConfig::from(label))
+                    .style()
+                    .align_self(AlignSelf::Start)
+                    .font_size(20.)
+                    .font_color(css::GREEN.into())
+                    .id();
+            },
+        );
+        builder.insert(TitleLabel { title: t, label: l });
+        builder
+    }
+}
+
+#[extension_trait]
+impl TitledLabelSubExt for UiBuilder<'_, (Entity, TitleLabel)> {
+    // access the different subwidgets here
+    fn value(&mut self, builder: impl FnOnce(&mut UiBuilder<'_, Entity>)) -> &mut Self {
+        let e = self.content().label;
+        let mut vb = self.commands().ui_builder(e);
+        builder(&mut vb);
+        self
+    }
+
+    // access the different subwidgets here
+    fn title(&mut self, builder: impl FnOnce(&mut UiBuilder<'_, Entity>)) -> &mut Self {
+        let e = self.content().title;
+        let mut vb = self.commands().ui_builder(e);
+        builder(&mut vb);
+        self
+    }
+}
+
+#[extension_trait]
+impl SetTextExt for UiStyle<'_> {
+    fn set_text(&mut self, text: impl Into<String>) -> &mut Self {
+        self.entity_commands().add(SetText(text.into()));
+        self
+    }
+}
+
+pub struct SetText(String);
+
+impl EntityCommand for SetText {
+    fn apply(self, id: Entity, world: &mut World) {
+        if let Some(mut text) = world.entity_mut(id).get_mut::<Text>() {
+            if let Some(section) = text.sections.first_mut() {
+                section.value = self.0;
+            }
+        }
+    }
+}
+
+#[derive(Component, Clone, Copy)]
+pub struct TitleLabel {
+    #[allow(unused)]
+    title: Entity,
+    label: Entity,
+}
+
+#[derive(Component, Clone, Copy)]
+pub struct Root {
+    pub label_one: Entity,
+    pub label_two: Entity,
+}
+
+#[extension_trait]
+impl RootExt for UiBuilder<'_, (Entity, Root)> {
+    fn titled_label_one(
+        &mut self,
+        // we borrow the query to get acces to the titlelabel
+        title_labels: &Query<&TitleLabel>,
+        builder: impl FnOnce(&mut UiBuilder<(Entity, TitleLabel)>),
+    ) -> &mut Self {
+        let entity = self.context().1.label_one;
+        let tl = title_labels.get(entity).unwrap();
+        let mut tl = self.commands().ui_builder((entity, tl.clone()));
+        builder(&mut tl);
+        self
+    }
+
+    fn titled_label_two(
+        &mut self,
+        title_labels: &Query<&TitleLabel>,
+        builder: impl FnOnce(&mut UiBuilder<(Entity, TitleLabel)>),
+    ) -> &mut Self {
+        let entity = self.context().1.label_two;
+        let tl = title_labels.get(entity).unwrap();
+        let mut tl = self.commands().ui_builder((entity, tl.clone()));
+        builder(&mut tl);
+        self
+    }
+}
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            title: "Sickle UI -  Simple Editor".into(),
+            resolution: (1280., 720.).into(),
+            ..default()
+        }),
+        ..default()
+    }))
+    .add_plugins(SickleUiPlugin)
+    .add_systems(Startup, setup)
+    .add_systems(Update, modify_labels)
+    .run();
+}
+
+// shows how to change styles on the ui elements
+fn modify_labels(
+    time: Res<Time>,
+    mut frames: Local<usize>,
+
+    // these could go into a SystemParam, on which methods could be created, if wished
+    mut commands: Commands,
+    q: Query<(Entity, &Root)>,
+    title_labels: Query<&TitleLabel>,
+) {
+    let (root_e, root) = q.single();
+
+    *frames += 1;
+
+    commands
+        // make sure we get a contexted builder of type 'UiBuilder<'_, (Entity, Root)>'
+        .ui_builder((root_e, root.clone()))
+        // because it enables this method, that allows us to target the specific titlelabel in the closure
+        .titled_label_one(&title_labels, |title_label| {
+            // which enables this method to label part of the of the first 'TitleLabel' widget
+            title_label.value(|value| {
+                value
+                    .style()
+                    .set_text(frames.to_string())
+                    // all the regular style values are available as well
+                    .font_size((*frames % 100 + 10) as f32);
+            });
+        })
+        // and here we acecs the second titlevalue on root
+        .titled_label_two(&title_labels, |title_label| {
+            // and modify its valuewe acecs the second titlevalue on root
+            title_label.title(|title| {
+                title
+                    .style()
+                    .set_text(format!("Duration: {}", time.elapsed_seconds()));
+            });
+        });
+}
+
+fn setup(mut commands: Commands) {
+    // The main camera which will render UI
+    commands.spawn((Camera3dBundle {
+        camera: Camera {
+            order: 1,
+            clear_color: Color::BLACK.into(),
+            ..default()
+        },
+        transform: Transform::from_translation(Vec3::new(0., 30., 0.))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    },));
+
+    // Use the UI builder with plain bundles and direct setting of bundle props
+
+    let mut label_one = Entity::PLACEHOLDER;
+    let mut label_two = Entity::PLACEHOLDER;
+    commands
+        .ui_builder(UiRoot)
+        .container(NodeBundle::default(), |root| {
+            root.style()
+                .width(Val::Px(100.))
+                .height(Val::Px(100.))
+                .flex_direction(FlexDirection::Column)
+                .justify_content(JustifyContent::Center)
+                .align_content(AlignContent::Center);
+
+            label_one = root
+                .titled_label("Changing Value Part", "this changes in the system")
+                .id();
+            label_two = root
+                .titled_label("This changes in the system", "Changing title part")
+                .id();
+        })
+        .insert(Root {
+            label_one,
+            label_two,
+        });
+}

--- a/examples/widget.rs
+++ b/examples/widget.rs
@@ -187,8 +187,10 @@ fn modify_labels(
                             Srgba::rgb_u8(*frames as _, *frames as _, *frames as _).into(),
                         );
                     })
-                    .entity_commands()
-                    .set_text(format!("Duration: {}", time.elapsed_seconds()), None);
+                    // this keeps context after applying any entitycommands code
+                    .entity_commands_inplace(|ec| {
+                        ec.set_text(format!("Duration: {}", time.elapsed_seconds()), None);
+                    });
             });
         });
 }

--- a/examples/widget.rs
+++ b/examples/widget.rs
@@ -64,7 +64,7 @@ mod titlelabel_widget {
     pub impl TitledLabelSubExt for UiBuilder<'_, (Entity, &TitleLabel)> {
         // access the different subwidgets here
         fn value(&mut self, builder: impl FnOnce(&mut UiBuilder<'_, Entity>)) -> &mut Self {
-            let e = self.content().label;
+            let e = self.context_data().label;
             let mut vb = self.commands().ui_builder(e);
             builder(&mut vb);
             self
@@ -72,7 +72,7 @@ mod titlelabel_widget {
 
         // access the different subwidgets here
         fn title(&mut self, builder: impl FnOnce(&mut UiBuilder<'_, Entity>)) -> &mut Self {
-            let e = self.content().title;
+            let e = self.context_data().title;
             let mut vb = self.commands().ui_builder(e);
             builder(&mut vb);
             self


### PR DESCRIPTION
Created an example of creating custom widgets, and examples of modifications of those widgets with widgetlike trees, wasnt that minimal, but covers the basics to get of to an advanced start if one wants to

Didnt figure out any nicer way of getting the Component that is required for the typed 'UiBuilder<'_, (Entity, Component)>'
and also it was so tedious to create the extension traits when trying to get a reference to the component.

And I still included the extension trait crate as dev-dep, to showcase an even easier use that is optional for users of this great library!